### PR TITLE
add tps and cpuRunningThreads in metrics table (missing)

### DIFF
--- a/_users/Metrics.md
+++ b/_users/Metrics.md
@@ -38,9 +38,11 @@ static final Logger log = LoggerFactory.getLogger("${Logger名}");
 | averageTimeInQueue                       | Producer端调用在队列中的平均时间  |
 | countInQueue                             | Producer端在队列中等待的调用的数量 |
 | cpuLoad                                  | 实例CPU使用率              |
+| cpuRunningThreads                        | 实例运行线程数量              |
 | heapCommit，heapInit，heapMax，heapUsed     | 内存Heap使用状况            |
 | nonHeapCommit，nonHeapInit，nonHeapMax，nonHeapUsed | 内存NonHeap使用状况         |
 | latency                                  | 调用平均时延                |
+| tps                                      | 每秒调用数（Transaction per seconds）  |
 | maxLifeTimeInQueue                       | Producer端调用在队列中最大等待时间 |
 | minLifeTimeInQueue                       | Producer端调用在队列中最小等待时间 |
 | totalRequestsPerProvider                 | Producer总请求数          |


### PR DESCRIPTION
missing tps and cpuRunningThreads description in metrics table