### PR TITLE
update footer github url

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -29,7 +29,7 @@
             <a href="mailto:dev-subscribe@servicecomb.incubator.apache.org" rel="nofollow"><span class="mail">{{ site.data.ui-text[page.lang].mailing_list | default: "Mailing List" }}</span></a>
         </li>
         <li>
-            <a href="http://github.com/{{ site.author.github }}" target="_blank"><span class="github">Github</span></a>
+            <a href="https://github.com/apache?q=ServiceComb" target="_blank"><span class="github">Github</span></a>
         </li>
         <li>
             <a href="https://twitter.com/{{ site.twitter.username }}" target="_blank"><span class="twitter">Twitter</span></a>


### PR DESCRIPTION
Signed-off-by: zhengyangyong <yangyong.zheng@huawei.com>
update footer github url from http://github.com/{{ site.author.github }} to https://github.com/apache?q=ServiceComb