### PR TITLE
Split General Development/Use ServiceComb in Spring Boot document

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -54,6 +54,8 @@ t:
             url: /users/develop-with-jax-rs/
           - title: Develop Microservice with Transparent RPC
             url: /users/develop-with-transparent-rpc/
+          - title: Develop Microservice with Spring Boot Starter
+            url: /users/develop-with-spring-boot-starter/
           - title: Service Interface Constraints
             url: /users/service-interface-constraints/
           - title: Service Configurations
@@ -80,8 +82,6 @@ t:
         children:
           - title: Develop and Test in Local Environment
             url: /users/local-develop-test/
-          - title: Use ServiceComb in Spring Boot
-            url: /users/use-servicecomb-in-spring-boot/
           - title: Distributed Tracing
             url: /users/distributed-tracing/
           - title: Customized Tracing
@@ -90,7 +90,7 @@ t:
       - title: Dynamic Configurations
         url: /users/dynamic-config/
 
-      - title: Edging Service
+      - title: Open Service Capabilities
         children:
           - title: Confd and Nginx Edge Service
             url: /users/edging-service/nginx/
@@ -98,6 +98,8 @@ t:
             url: /users/edging-service/zuul/
           - title: ServiceComb Java Chassis Edge Service
             url: /users/edge-in-1.0.0-m1/
+          - title: Using the Service Center and Governance Center to Manage the Spring Cloud Application
+            url: /users/manage_springcloud_application_using_sc_and_gs/
 
       - title: Monitor
         children:
@@ -211,6 +213,8 @@ t:
             url: /cn/users/develop-with-jax-rs/
           - title: 用透明RPC开发微服务
             url: /cn/users/develop-with-transparent-rpc/
+          - title: 用Spring Boot Starter开发微服务
+            url: /cn/users/develop-with-spring-boot-starter/
           - title: 服务接口约束
             url: /cn/users/service-interface-constraints/
           - title: 服务配置
@@ -237,8 +241,6 @@ t:
         children:
           - title: 本地开发与测试
             url: /cn/users/local-develop-test/
-          - title: 在Spring Boot中使用ServiceComb
-            url: /cn/users/use-servicecomb-in-spring-boot/
           - title: 分布式调用链追踪
             url: /cn/users/distributed-tracing/
           - title: 自定义调用链打点
@@ -255,6 +257,8 @@ t:
             url: /cn/users/edging-service/zuul/
           - title: 使用内置Edge模块实现边缘服务
             url: /cn/users/edge-in-1.0.0-m1/
+          - title: 使用Service Center和治理中心管理Spring Cloud应用
+            url: /cn/users/manage_springcloud_application_using_sc_and_gs/
 
       - title: 监控
         children:

--- a/_users/cn/develop-with-springboot-starter.md
+++ b/_users/cn/develop-with-springboot-starter.md
@@ -1,0 +1,147 @@
+---
+title: "用Spring Boot Starter开发微服务"
+lang: cn
+ref: develop-with-spring-boot-starter
+permalink: /cn/users/develop-with-spring-boot-starter/
+excerpt: "用Spring Boot Starter开发微服务"
+last_modified_at: 2018-04-23T15:01:43-04:00
+redirect_from:
+  - /theme-setup/
+---
+
+{% include toc %}
+## 概念阐述
+### SpringBoot框架
+Spring Boot是由Pivotal团队提供的全新框架，其设计目的是用来简化新Spring应用的初始搭建以及开发过程。该框架使用了特定的方式来进行配置，从而使开发人员不再需要定义样板化的配置。从最根本上来讲，Spring Boot就是一些库的集合，它能够被任意项目的构建系统所使用。Boot的功能是模块化的，通过导入Boot所谓的"starter"模块，可以将许多的依赖添加到工程中。
+
+### 在ServiceComb中集成SpringBoot
+使用原生的ServiceComb框架开发微服务应用，如若需要使用ServiceComb框架提供的各项功能服务，需要在微服务项目工程pom文件中添加相应的依赖包，例如需要使用ServiceComb框架提供的负载均衡服务，需要添加handler-loadbalance包依赖。这样可以把ServiceComb提供的能力以starter的方式插入Spring Boot中，同时使用Spring Boot中提供的其他开箱即用的starter（例如SpringCloud）一起构建微服务。
+
+## 开发示例
+* **步骤 1** 添加依赖。
+
+   在Maven的pom.xml中添加所需的依赖：
+   
+   ```xml
+<dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.apache.servicecomb</groupId>
+        <artifactId>java-chassis-dependencies</artifactId>
+        <version>${java-chassis.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+</dependencyManagement>
+<dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter</artifactId>
+    </dependency>
+    <!--spring-boot-starter-provider中已经包含transport-rest-vertx和transport-highway-->
+    <dependency>
+      <groupId>org.apache.servicecomb</groupId>
+      <artifactId>spring-boot-starter-provider</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.hibernate</groupId>
+      <artifactId>hibernate-validator</artifactId>
+    </dependency>
+</dependencies>
+   ```
+
+* **步骤 2** 实现服务。
+
+   使用Spring MVC注解开发业务代码，Hello的服务实现如下：
+
+   ```java
+   import javax.ws.rs.core.MediaType;
+   import org.springframework.web.bind.annotation.RequestBody;
+   import org.springframework.web.bind.annotation.RequestMapping;
+   import org.springframework.web.bind.annotation.RequestMethod;
+   import org.springframework.web.bind.annotation.RequestParam;
+   import org.apache.servicecomb.samples.common.schema.models.Person;
+   
+   @RequestMapping(path = "/springmvchello", produces = MediaType.APPLICATION_JSON)
+   public class SpringmvcHelloImpl {
+     @RequestMapping(path = "/sayhi", method = RequestMethod.POST)
+     public String sayHi(@RequestParam(name = "name") String name) {
+   　  return "Hello " + name;
+     }
+
+     @RequestMapping(path = "/sayhello", method = RequestMethod.POST)
+     public String sayHello(@RequestBody Person person) {
+   　  return "Hello person " + person.getName();
+   　}
+   }
+   ```
+
+* **步骤 3** 发布服务
+
+   在服务的实现类上打上注解@RestSchema，指定schemaId，表示该实现作为当前微服务的一个schema发布，代码如下：
+
+   ```java
+   import org.apache.servicecomb.provider.rest.common.RestSchema;
+   // other code omitted
+   @RestSchema(schemaId = "springmvcHello")
+   public class SpringmvcHelloImpl {
+     // other code omitted
+   }
+   ```
+
+   然后在`resources/META-INF/spring`目录下创建`springmvcHello.bean.xml`文件，命名规则为`\*.bean.xml`，配置spring进行服务扫描的base-package，文件内容如下：
+
+   ```xml
+   <?xml version="1.0" encoding="UTF-8"?>
+   
+   <beans xmlns="http://www.springframework.org/schema/beans"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xmlns:context="http://www.springframework.org/schema/context"
+          xsi:schemaLocation="http://www.springframework.org/schema/beans classpath:org/springframework/beans/factory/xml/spring-beans-3.0.xsd
+          http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.0.xsd">
+   
+       <context:component-scan base-package="org.apache.servicecomb.samples.springmvc.provider"/>
+   </beans>
+   ```
+
+> **说明**：
+Spring Boot已经包含了默认的Bean扫描策略，如果能够保证Spring Boot能够找到我们的`SpringmvcHelloImpl`，那么无需定义`springmvcHello.bean.xml`。
+
+* **步骤 4** 添加服务定义。
+
+   在resources目录中添加[microservice.yaml](http://servicecomb.incubator.apache.org/cn/users/service-definition/)。
+   
+* **步骤 5** 添加Main启动类
+
+   ```java
+    import org.apache.servicecomb.springboot.starter.provider.EnableServiceComb;
+    import org.springframework.boot.SpringApplication;
+    import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+    @SpringBootApplication
+    //EnableServiceComb注解用于在Spring Boot程序内拉起ServiceComb
+    @EnableServiceComb
+    public class Application {
+      public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+      }
+    }
+   ```
+
+## 涉及API
+
+用Spring Boot Starter开发微服务同样使用Spring MVC开发模式，当前支持org.springframework.web.bind.annotation包下的如下注解，所有注解的使用方法参考[Spring MVC官方文档](https://docs.spring.io/spring/docs/current/spring-framework-reference/html/mvc.html)。
+
+| 注解 | 位置 | 描述 |
+| :--- | :--- | :--- |
+| RequestMapping | schema/operation | 支持标注path/method/produces三种数据，operation默认继承schema上的produces |
+| GetMapping | schema/operation | 支持标注path/produces两种数据，operation默认继承schema上的produces |
+| PutMapping | schema/operation | 支持标注path/produces两种数据，operation默认继承schema上的produces |
+| PostMapping | schema/operation | 支持标注path/produces两种数据，operation默认继承schema上的produces |
+| DeleteMapping | schema/operation | 支持标注path/produces两种数据，operation默认继承schema上的produces |
+| PatchMapping | schema/operation | 支持标注path/produces两种数据，operation默认继承schema上的produces |
+| PathVariable | parameter | 从path中获取参数 |
+| RequestParam | parameter | 从query中获取参数 |
+| RequestHeader | parameter | 从header中获取参数 |
+| RequestBody | parameter | 从body中获取参数，每个operation只能有一个body参数 |

--- a/_users/cn/develop-with-springboot-starter.md
+++ b/_users/cn/develop-with-springboot-starter.md
@@ -22,34 +22,34 @@ Spring Boot是由Pivotal团队提供的全新框架，其设计目的是用来�
 
    在Maven的pom.xml中添加所需的依赖：
    
-   ```xml
-<dependencyManagement>
+    ```xml
+    <dependencyManagement>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.servicecomb</groupId>
+            <artifactId>java-chassis-dependencies</artifactId>
+            <version>1.0.0-m1</version>
+            <type>pom</type>
+            <scope>import</scope>
+          </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
-      <dependency>
-        <groupId>org.apache.servicecomb</groupId>
-        <artifactId>java-chassis-dependencies</artifactId>
-        <version>${java-chassis.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
+        <dependency>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-starter</artifactId>
+        </dependency>
+        <!--spring-boot-starter-provider中已经包含transport-rest-vertx和transport-highway-->
+        <dependency>
+          <groupId>org.apache.servicecomb</groupId>
+          <artifactId>spring-boot-starter-provider</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.hibernate</groupId>
+          <artifactId>hibernate-validator</artifactId>
+        </dependency>
     </dependencies>
-</dependencyManagement>
-<dependencies>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter</artifactId>
-    </dependency>
-    <!--spring-boot-starter-provider中已经包含transport-rest-vertx和transport-highway-->
-    <dependency>
-      <groupId>org.apache.servicecomb</groupId>
-      <artifactId>spring-boot-starter-provider</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.hibernate</groupId>
-      <artifactId>hibernate-validator</artifactId>
-    </dependency>
-</dependencies>
-   ```
+    ```
 
 * **步骤 2** 实现服务。
 

--- a/_users/cn/manage_springcloud_application_using_sc_and_gs.md
+++ b/_users/cn/manage_springcloud_application_using_sc_and_gs.md
@@ -1,21 +1,20 @@
 ---
-title: "在Spring Boot中使用ServiceComb"
+title: "使用Service Center和治理中心管理Spring Cloud应用"
 lang: cn
-ref: use-servicecomb-in-spring-boot
-permalink: /cn/users/use-servicecomb-in-spring-boot/
-excerpt: "在Spring Boot中使用ServiceComb"
-last_modified_at: 2017-08-15T15:01:43-04:00
+ref: manage_springcloud_application_using_sc_and_gs
+permalink: /cn/users/manage_springcloud_application_using_sc_and_gs/
+excerpt: "使用Service Center和治理中心管理Spring Cloud应用"
+last_modified_at: 2018-04-23T15:01:43-04:00
 redirect_from:
   - /theme-setup/
 ---
 
 {% include toc %}
-## 使用Service Center和治理中心管理Spring Cloud应用
-### 概念阐述
+## 概念阐述
 
-本小节介绍在SpringCloud原生应用中，通过改变相关配置，让SpringCloud应用使用ServiceComb微服务框架中的Service Center和治理中心。
+在SpringCloud原生应用中，通过改变相关配置，让SpringCloud应用使用ServiceComb微服务框架中的Service Center和治理中心。
 
-### 场景描述
+## 场景描述
 
 * SpringCloud应用默认情况下由Spring Cloud Eureka提供在分布式环境下的服务发现和服务注册的功能。
 
@@ -142,90 +141,3 @@ redirect_from:
    ```
 
 * **步骤 7** 启动xxxServer，该服务便可注册到ServiceComb的Service Center。
-
-
-## 在ServiceComb框架中集成Spring Boot框架
-### 概念阐述
-
-本小节介绍了在ServiceComb框架中集成SpringBoot框架的好处和操作步骤。
-
-### 场景描述
-
-#### **SpringBoot框架**
-
-　　Spring Boot是由Pivotal团队提供的全新框架，其设计目的是用来简化新Spring应用的初始搭建以及开发过程。该框架使用了特定的方式来进行配置，从而使开发人员不再需要定义样板化的配置。从最根本上来讲，Spring Boot就是一些库的集合，它能够被任意项目的构建系统所使用。Boot的功能是模块化的，通过导入Boot所谓的"starter"模块，可以将许多的依赖添加到工程中。
-
-#### **在ServiceComb中集成SpringBoot**
-
-　　使用原生的ServiceComb框架开发微服务应用，如若需要使用ServiceComb框架提供的各项功能服务，需要在微服务项目工程pom文件中添加相应的依赖包，例如需要使用ServiceComb框架提供的负载均衡服务，需要添加handler-loadbalance包依赖。这样可以把ServiceComb提供的能力以starter的方式插入Spring Boot中，同时使用Spring Boot中提供的其他开箱即用的starter（例如SpringCloud）一起构建微服务。
-
-### ServiceComb集成SpringBoot
-
-　　首先使用ServiceComb框架开发微服务应用，详细步骤请参考[开发服务提供者](/cn/users/service-definition/)与[开发服务消费者](/cn/users/develop-with-rest-template/)。然后在这个基础上集成SpringBoot框架。
-
-　　在对应用进行SpringBoot框架适配前，请确保应用能够正常运行，并且能够从中央的maven库下载依赖的资源。
-
-* **步骤 1** 在工程pom文件添加&lt;dependencyManagement&gt;节点：
-
-   ```xml
-   <dependencyManagement>
-     <dependencies>
-       <dependency>
-         <groupId>org.apache.servicecomb</groupId>
-         <artifactId>java-chassis-dependencies</artifactId>
-         <version>1.0.0-m1</version>
-         <type>pom</type>
-         <scope>import</scope>
-       </dependency>
-     </dependencies>
-   </dependencyManagement>
-   ```
-
-* **步骤 2** 添加如下依赖：
-
-   引入ServiceComb提供的Spring Boot依赖
-
-   ```xml
-   <dependency>
-     <groupId>org.apache.servicecomb</groupId>
-     <artifactId>spring-boot-starter-provider</artifactId>
-   </dependency>
-   ```
-
-   引入Spring Boot依赖
-
-   ```xml
-   <dependency>
-     <groupId>org.springframework.boot</groupId>
-     <artifactId>spring-boot-starter-web</artifactId>
-   </dependency>
-   <dependency>
-     <groupId>org.springframework.boot</groupId>
-     <artifactId>spring-boot-starter-actuator</artifactId>
-   </dependency>
-   ```
-
-* **步骤 3** 在resources目录下新建application.yml文件，文件内容如下：
-
-   ```yaml
-   server:
-     port: 7999 #此处的端口为springboot服务端口
-   ```
-
-* **步骤 4** 为微服务启动类添加注解：
-
-   ```java
-   package xxx
-   import xxx
-   @SpringBootApplication //新增注解
-   @EnableServiceComb //新增注解
-   public class xxxServer/Client {
-     public static void main(final String[] args) {
-     　 Log4jUtils.init();
-     　//BeanUtils.init();
-     　SpringApplication.run(xxxServerOrClient.class, args)
-     }
-   }
-   ```
-
-* **步骤 5** 运行/调试应用。

--- a/_users/develop-with-jax-rs.md
+++ b/_users/develop-with-jax-rs.md
@@ -1,9 +1,9 @@
 ---
-title: "Development Style-JAX-RS"
+title: "Develop Microservice with JAX-RS"
 lang: en
 ref: develop-with-jax-rs
 permalink: /users/develop-with-jax-rs/
-excerpt: "Development Style-JAX-RS"
+excerpt: "Develop Microservice with JAX-RS"
 last_modified_at: 2017-08-15T15:01:43-04:00
 redirect_from:
   - /theme-setup/

--- a/_users/develop-with-springboot-starter.md
+++ b/_users/develop-with-springboot-starter.md
@@ -1,9 +1,9 @@
 ---
-title: "Develop Microservice with SpringMVC"
+title: "Develop Microservice with Spring Boot Starter"
 lang: en
-ref: develop-with-springmvc
-permalink: /users/develop-with-springmvc/
-excerpt: "Develop Microservice with SpringMVC"
+ref: develop-with-spring-boot-starter
+permalink: /users/develop-with-spring-boot-starter/
+excerpt: "Develop Microservice with Spring Boot Starter"
 last_modified_at: 2017-08-15T15:01:43-04:00
 redirect_from:
   - /theme-setup/
@@ -11,44 +11,41 @@ redirect_from:
 
 {% include toc %}
 ## Concept Description
-
-ServiceComb supports Spring MVC remark and allows you to develop microservices in Spring MVC mode.
-
+### **Spring Boot framework**
+Spring Boot is a new framework provided by the Pivotal team. It is designed to simplify the initial establishment and development of new Spring applications. The framework is configured in a specific manner so that developers do not need to define the sample configuration. Spring Boot is a collection of some databases and can be used by the construction system of any projects. The Boot function is modularized. By importing the starter module of Spring Boot, you can add many dependencies to a project.
+### **Integrating Spring Boot into ServicComb**
+You need to use the native Java Chassis framework to develop microservice applications. To use the functions provided by the Java Chassis framework, add dependency packages to the POM file of microservice project. For example, to use the load balancing service provided by the Java Chassis framework, add the dependency package of the handler-loadbalance package. In this way, functions provided by ServiceComb can be inserted into Spring Boot in the manner of starter, and the microservice can be built together with the starter (such as Spring Cloud) provided by Spring Boot.
 ## Development Example
 
 * **Step 1** Import dependencies into your maven project:
 
    ```xml
-    <dependencyManagement>
-     <dependencies>
+   <dependencyManagement>
+       <dependencies>
+         <dependency>
+           <groupId>org.apache.servicecomb</groupId>
+           <artifactId>java-chassis-dependencies</artifactId>
+           <version>${java-chassis.version}</version>
+           <type>pom</type>
+           <scope>import</scope>
+         </dependency>
+       </dependencies>
+   </dependencyManagement>
+   <dependencies>
+       <dependency>
+         <groupId>org.springframework.boot</groupId>
+         <artifactId>spring-boot-starter</artifactId>
+       </dependency>
+       <!--spring-boot-starter-provider had included transport-rest-vertx and transport-highway-->
        <dependency>
          <groupId>org.apache.servicecomb</groupId>
-         <artifactId>java-chassis-dependencies</artifactId>
-         <version>1.0.0-m1</version>
-         <type>pom</type>
-         <scope>import</scope>
+         <artifactId>spring-boot-starter-provider</artifactId>
        </dependency>
-     </dependencies>
-    </dependencyManagement>
-    <dependencies>
-      <!--transport can optional import through endpoint setting in microservice.yaml, we import both rest and highway as example-->
-      <dependency>
-        <groupId>org.apache.servicecomb</groupId>
-        <artifactId>transport-rest-vertx</artifactId>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.servicecomb</groupId>
-        <artifactId>transport-highway</artifactId>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.servicecomb</groupId>
-        <artifactId>provider-springmvc</artifactId>
-      </dependency>
-      <dependency>
-        <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-log4j12</artifactId>
-      </dependency>
-    </dependencies>
+       <dependency>
+         <groupId>org.hibernate</groupId>
+         <artifactId>hibernate-validator</artifactId>
+       </dependency>
+   </dependencies>
    ```
 
 * **Step 2** Implement the services. Spring MVC is used to describe the development of service code. The implementation of the Hello service is as follow:
@@ -101,6 +98,9 @@ ServiceComb supports Spring MVC remark and allows you to develop microservices i
    </beans>
    ```
 
+> **NOTE**：
+Spring Boot had include a default Bean discovery policy, if Spring Boot can found our `SpringmvcHelloImpl`, `springmvcHello.bean.xml` is not necessary.
+
 * **Step 4** Add service definition file:
 
    Add [microservice.yaml](http://servicecomb.incubator.apache.org/cn/users/service-definition/) file into resources folder of your project.
@@ -108,21 +108,23 @@ ServiceComb supports Spring MVC remark and allows you to develop microservices i
 * **Step 5** Add Main class:
 
    ```java
-   import org.apache.servicecomb.foundation.common.utils.BeanUtils;
-   import org.apache.servicecomb.foundation.common.utils.Log4jUtils;
+    import org.apache.servicecomb.springboot.starter.provider.EnableServiceComb;
+    import org.springframework.boot.SpringApplication;
+    import org.springframework.boot.autoconfigure.SpringBootApplication;
 
-   public class Application {
-     public static void main(String[] args) throws Exception {
-        //initializing log, loading bean(including its parameters), and registering service, more detail can be found here : http://servicecomb.incubator.apache.org/users/application-boot-process/
-        Log4jUtils.init();
-        BeanUtils.init();
-     }
-   }
+    @SpringBootApplication
+    //EnableServiceComb annotation is used to init ServiceComb in Spring Boot
+    @EnableServiceComb
+    public class Application {
+      public static void main(String[] args) {
+        SpringApplication.run(Application.class, args);
+      }
+    }
    ```
 
 ## Involved APIs
 
-Currently, the Spring MVC development mode supports the following annotations in the org.springframework.web.bind.annotation package. For details about how to use the annotations, see [Spring MVC official documentation](https://docs.spring.io/spring/docs/current/spring-framework-reference/html/mvc.html)。
+Spring Boot Starter also use the Spring MVC development mode, supports the following annotations in the org.springframework.web.bind.annotation package. For details about how to use the annotations, see [Spring MVC official documentation](https://docs.spring.io/spring/docs/current/spring-framework-reference/html/mvc.html)。
 
 | Remarks        | Location         | Description                              |
 | :------------- | :--------------- | :--------------------------------------- |

--- a/_users/develop-with-springboot-starter.md
+++ b/_users/develop-with-springboot-starter.md
@@ -25,7 +25,7 @@ You need to use the native Java Chassis framework to develop microservice applic
          <dependency>
            <groupId>org.apache.servicecomb</groupId>
            <artifactId>java-chassis-dependencies</artifactId>
-           <version>${java-chassis.version}</version>
+           <version>1.0.0-m1</version>
            <type>pom</type>
            <scope>import</scope>
          </dependency>

--- a/_users/develop-with-transparent-rpc.md
+++ b/_users/develop-with-transparent-rpc.md
@@ -1,9 +1,9 @@
 ---
-title: "Development Style-Transparent RPC"
+title: "Develop Microservice with Transparent RPC"
 lang: en
 ref: develop-with-transparent-rpc
 permalink: /users/develop-with-transparent-rpc/
-excerpt: "Development Style-RPC"
+excerpt: "Develop Microservice with Transparent RPC"
 last_modified_at: 2017-08-15T15:01:43-04:00
 redirect_from:
   - /theme-setup/

--- a/_users/manage_springcloud_application_using_sc_and_gs.md
+++ b/_users/manage_springcloud_application_using_sc_and_gs.md
@@ -1,21 +1,20 @@
 ---
-title: "Use ServiceComb in Spring Boot"
+title: "Using the Service Center and Governance Center to Manage the Spring Cloud Application"
 lang: en
-ref: use-servicecomb-in-spring-boot
-permalink: /users/use-servicecomb-in-spring-boot/
-excerpt: "Use ServiceComb in Spring Boot"
+ref: manage_springcloud_application_using_sc_and_gs
+permalink: /users/manage_springcloud_application_using_sc_and_gs/
+excerpt: "Using the Service Center and Governance Center to Manage the Spring Cloud Application"
 last_modified_at: 2017-08-15T15:01:43-04:00
 redirect_from:
   - /theme-setup/
 ---
 
 {% include toc %}
-## Using the Service Center and Governance Center to Manage the Spring Cloud Application
-### Concept Description
+## Concept Description
 
 This section describes how to change configurations in the native Spring Cloud application to allow the Spring Cloud application to use the service center and governance center in the microservice framework.
 
-### Scenario
+## Scenario
 
 * The Spring Cloud Eureka client provides the service discovery and service registration function in the distributed environment by default.
 
@@ -31,7 +30,7 @@ This section describes how to change configurations in the native Spring Cloud a
 
 You can use Spring Cloud or Spring Boot to develop applications, enable services run in the microservice SDK container, and use functions, such as high-performance communication, service governance, and distributed transaction management.
 
-### Configuration Description
+## Configuration Description
 
 Use Spring Boot or Spring Cloud to develop applications and perform the following steps based on the original application to interconnect with the SDK components of ServiceComb.
 
@@ -142,86 +141,3 @@ NOTE， If your java chassis version is or below 0.5.0, please use the io.servic
    ```
 
 * **Step 7** Start the xxxServer. The service can be registered in the service center of ServiceComb.
-
-
-## Integrating Spring Boot into Java Chassis
-### Concept Description
-
-This section describes advantages and procedures of integrating the Spring Boot framework in the Java Chassis framework.
-
-### Scenario
-
-#### **Spring Boot framework**
-
-　　Spring Boot is a new framework provided by the Pivotal team. It is designed to simplify the initial establishment and development of new Spring applications. The framework is configured in a specific manner so that developers do not need to define the sample configuration. Spring Boot is a collection of some databases and can be used by the construction system of any projects. The Boot function is modularized. By importing the starter module of Spring Boot, you can add many dependencies to a project.
-
-#### **Integrating Spring Boot into ServicComb**
-
-　　You need to use the native Java Chassis framework to develop microservice applications. To use the functions provided by the Java Chaasis framework, add dependency packages to the POM file of microservice project. For example, to use the load balancing service provided by the Java Chassis framework, add the dependency package of the handler-loadbalance package. In this way, functions provided by ServiceComb can be inserted into Spring Boot in the manner of starter, and the microservice can be built together with the startere (such as Spring Cloud) provided by Spring B
-
-### Integrating Spring Boot into ServiceComb
-
-　　You need to use the Java Chassis framework to develop microservice applications, and then integrate the Spring Boot framework.
-
-* **Step 1** Add the dependency Management node to the POM file.
-
-   ```xml
-   <dependencyManagement>
-     <dependencies>
-       <dependency>
-         <groupId>org.apache.servicecomb</groupId>
-         <artifactId>java-chassis-dependencies</artifactId>
-         <version>1.0.0-m1</version>
-         <type>pom</type>
-         <scope>import</scope>
-       </dependency>
-     </dependencies>
-   </dependencyManagement>
-   ```
-
-* **Step 2** Add the following dependency:
-
-   Import Spring Boot dependency provided by ServiceComb
-
-   ```xml
-   <dependency>
-     <groupId>org.apache.servicecomb</groupId>
-     <artifactId>spring-boot-starter-provider</artifactId> 
-   </dependency>
-   ```
-
-   ```xml
-   <dependency>
-     <groupId>org.springframework.boot</groupId>
-     <artifactId>spring-boot-starter-web</artifactId>
-   </dependency>
-   <dependency>
-     <groupId>org.springframework.boot</groupId>
-     <artifactId>spring-boot-starter-actuator</artifactId>
-   </dependency>
-   ```
-
-* **Step 3** Create the application.yaml file in the resources directory. The file content is as follows:
-
-   ```yaml
-   server:
-     port: 7999 #Port number of the Spring Boot service
-   ```
-
-* **Step 4** Add the following annotation for the microservice main class:
-
-   ```java
-   package xxx
-   import xxx
-   @SpringBootApplication //New Annotation
-   @EnableServiceComb //New Annotation
-   public class xxxServer/Client {
-     public static void main(final String[] args) {
-     　 Log4jUtils.init();
-     　//BeanUtils.init();
-     　SpringApplication.run(xxxServerOrClient.class, args)
-     }
-   }
-   ```
-
-* **步骤 5** 运行/调试应用。


### PR DESCRIPTION
Signed-off-by: zhengyangyong <yangyong.zheng@huawei.com>

In the "General Development/Use ServiceComb in Spring Boot" document,it is include two topics:
1. Using the Service Center and Governance Center to Manage the Spring Cloud Application
2. How to develop Microservice with Spring Boot Starter

So I had split it into two document:
1.Open Service Capabilities/Using the Service Center and Governance Center to Manage the Spring Cloud Application (Spring zuul also here)
2.Develop Service Provider/Develop Microservice with Spring Boot Starter

**Fix develop producer documents titles by the way**
