### PR TITLE
Fix bug about  description of Rate Limiting Policy

### DIFF
--- a/_users/cn/service-configurations.md
+++ b/_users/cn/service-configurations.md
@@ -86,14 +86,24 @@ servicecomb：
 
 ### 配置说明
 
-　　限流策略配置在microservice.yaml文件中，相关配置项见下表。要开启服务提供者端的限流策略，还需要在处理链中配置服务端限流handler，配置示例如下：
+　　限流策略配置在microservice.yaml文件中，相关配置项见表2。要开启服务提供者端的限流策略，还需要在处理链中配置服务端限流handler，并添加pom依赖。
 
+* microservice.yaml配置示例如下：
 ```yaml
 servicecomb:
   handler:
     chain:
-      Consumer:
+      Provider:
         default: qps-flowcontrol-provider
+```
+
+* 添加handler-flowcontrol-qps的pom依赖：
+```yaml
+<dependency>
+    <groupId>org.apache.servicecomb</groupId>
+    <artifactId>handler-flowcontrol-qps</artifactId>
+    <version>1.0.0-m1</version>
+</dependency>
 ```
 
 　　**表2 QPS流控配置项说明**

--- a/_users/service-configurations.md
+++ b/_users/service-configurations.md
@@ -85,14 +85,24 @@ Users at the provider end can use the rate limiting policy to limit the maximum 
 
 ### Configuration
 
-　　Rate limiting policies are configured in the microservice.yaml file. For related configuration items, see Table 2. To enable the rate limiting policy at the provider end, you also need to configure the rate limiting handler on the server in the processing chain and add dependencies in the pom.xml file. An example of microservice.yaml file configuration is as follows:
+　　Rate limiting policies are configured in the microservice.yaml file. For related configuration items, see Table 2. To enable the rate limiting policy at the provider end, you also need to configure the rate limiting handler on the server in the processing chain and add dependencies in the pom.xml file. 
 
+* An example of microservice.yaml file configuration is as follows,
 ```yaml
 servicecomb:
   handler:
     chain:
-      Consumer:
+      Provider:
         default: qps-flowcontrol-provider
+```
+
+* Add dependencies of handler-flowcontrol-qps in the pom.xml file,
+```yaml
+<dependency>
+    <groupId>org.apache.servicecomb</groupId>
+    <artifactId>handler-flowcontrol-qps</artifactId>
+    <version>1.0.0-m1</version>
+</dependency>
 ```
 
 　　**Table2 Configuration items of the QPS rate limit**


### PR DESCRIPTION
The usage description of Rate Limiting Policy is wrong, so the user cannot use the function normally according to the description.

Signed-off-by: MabinGo <bin.ma@huawei.com>